### PR TITLE
Use var (instead of const) in the bundle banner

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -29,12 +29,13 @@ export async function buildAppSchema(entrypoint: string) {
     format: "esm",
     write: false,
     banner: {
-      js: `
-        import { createRequire } from "node:module";
-        const require = createRequire(import.meta.url);
-        const __dirname = import.meta.dirname;
-        const __filename = import.meta.filename;
-      `,
+      js: `// flowctl banner
+import { createRequire } from "node:module";
+var require = createRequire(import.meta.url);
+var __dirname = import.meta.dirname;
+var __filename = import.meta.filename;
+// end banner
+`,
     },
   });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "noEmit": true
   },
   "include": ["src"]
 }


### PR DESCRIPTION
Using `const` may conflict with some libraries that try to define their own polyfills.